### PR TITLE
BRIDGE-566/421

### DIFF
--- a/Parkinson/Startup/APHAppDelegate.m
+++ b/Parkinson/Startup/APHAppDelegate.m
@@ -46,7 +46,7 @@ static NSString *const kMyThoughtsSurveyIdentifier                  = @"8-MyThou
 /*********************************************************************************/
 static NSString *const kStudyIdentifier             = @"studyname";
 static NSString *const kAppPrefix                   = @"studyname";
-static NSString* const  kConsentPropertiesFileName  = @"APHConsentSection";
+static NSString *const kConsentPropertiesFileName   = @"APHConsentSection";
 
 static NSString *const kVideoShownKey = @"VideoShown";
 
@@ -180,6 +180,8 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
                                            }];
 
     self.initializationOptions = dictionary;
+    
+    self.showShareAppInOnboarding = YES;
 
     self.profileExtender = [[APHProfileExtender alloc] init];
 }


### PR DESCRIPTION
set showShareAppInOnboarding to true in order to see the share the app label/button when InEligible

Will need to link to updated AppCore in order to see controls
