### PR TITLE
Update share preference to use onboardingManager …

### DIFF
--- a/Parkinson/Startup/APHAppDelegate.m
+++ b/Parkinson/Startup/APHAppDelegate.m
@@ -181,7 +181,7 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
 
     self.initializationOptions = dictionary;
     
-    self.showShareAppInOnboarding = YES;
+    self.onboardingManager.showShareAppInOnboarding = YES;
 
     self.profileExtender = [[APHProfileExtender alloc] init];
 }


### PR DESCRIPTION
instead of setting directly in AppDelegate

These changes are to align with a recent refactor of appcore to move these sorts of settings out of the AppDelegate which seems like a sensible change.
