### PR TITLE
Update reminder task ids

### DIFF
--- a/Parkinson/Startup/APHAppDelegate.m
+++ b/Parkinson/Startup/APHAppDelegate.m
@@ -40,9 +40,7 @@ static NSString *const kVoiceActivitySurveyIdentifier               = @"3-APHPho
 static NSString *const kTappingActivitySurveyIdentifier             = @"2-APHIntervalTapping-7259AC18-D711-47A6-ADBD-6CFCECDED1DF";
 static NSString *const kMemoryActivitySurveyIdentifier              = @"7-APHSpatialSpanMemory-4A04F3D0-AC05-11E4-AB27-0800200C9A66";
 static NSString *const kMyThoughtsSurveyIdentifier                  = @"mythoughts";
-static NSString *const kPDRatingScaleSurveyIdentifier               = @"MDSUPDRS";
 static NSString *const kEnrollmentSurveyIdentifier                  = @"EnrollmentSurvey";
-static NSString *const kPDQuestionnaireSurveyIdentifier             = @"PDQ8";
 static NSString *const kStudyFeedbackSurveyIdentifier               = @"study_feedback";
 
 
@@ -177,9 +175,7 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
     APCTaskReminder *tappingActivityReminder = [[APCTaskReminder alloc] initWithTaskID:kTappingActivitySurveyIdentifier reminderBody:NSLocalizedString(@"Tapping Activity", nil)];
     APCTaskReminder *memoryActivityReminder = [[APCTaskReminder alloc] initWithTaskID:kMemoryActivitySurveyIdentifier reminderBody:NSLocalizedString(@"Memory Activity", nil)];
     APCTaskReminder *myThoughtsSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kMyThoughtsSurveyIdentifier reminderBody:NSLocalizedString(@"My Thoughts", nil)];
-    APCTaskReminder *pdRatingSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kPDRatingScaleSurveyIdentifier reminderBody:NSLocalizedString(@"PD Rating Scale", nil)];
     APCTaskReminder *enrollmentSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kEnrollmentSurveyIdentifier reminderBody:NSLocalizedString(@"Enrollment Survey", nil)];
-    APCTaskReminder *pdQuestionnaireSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kPDQuestionnaireSurveyIdentifier reminderBody:NSLocalizedString(@"PD Questionnaire", nil)];
     APCTaskReminder *studyFeedbackSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kStudyFeedbackSurveyIdentifier reminderBody:NSLocalizedString(@"Study Feedback", nil)];
 
     [self.tasksReminder.reminders removeAllObjects];
@@ -188,9 +184,7 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
     [self.tasksReminder manageTaskReminder:tappingActivityReminder];
     [self.tasksReminder manageTaskReminder:memoryActivityReminder];
     [self.tasksReminder manageTaskReminder:myThoughtsSurveyReminder];
-    [self.tasksReminder manageTaskReminder:pdRatingSurveyReminder];
     [self.tasksReminder manageTaskReminder:enrollmentSurveyReminder];
-    [self.tasksReminder manageTaskReminder:pdQuestionnaireSurveyReminder];
     [self.tasksReminder manageTaskReminder:studyFeedbackSurveyReminder];
 
     if ([self doesPersisteStoreExist] == NO)

--- a/Parkinson/Startup/APHAppDelegate.m
+++ b/Parkinson/Startup/APHAppDelegate.m
@@ -50,8 +50,8 @@ static NSString *const kStudyFeedbackSurveyIdentifier               = @"study_fe
 /*********************************************************************************/
 #pragma mark - Initializations Options
 /*********************************************************************************/
-static NSString *const kStudyIdentifier             = @"Parkinson's";
-static NSString *const kAppPrefix                   = @"parkinson";
+static NSString *const kStudyIdentifier             = @"studyname";
+static NSString *const kAppPrefix                   = @"studyname";
 static NSString *const kConsentPropertiesFileName   = @"APHConsentSection";
 
 static NSString *const kVideoShownKey = @"VideoShown";

--- a/Parkinson/Startup/APHAppDelegate.m
+++ b/Parkinson/Startup/APHAppDelegate.m
@@ -39,13 +39,19 @@ static NSString *const kWalkingActivitySurveyIdentifier             = @"4-APHTim
 static NSString *const kVoiceActivitySurveyIdentifier               = @"3-APHPhonation-C614A231-A7B7-4173-BDC8-098309354292";
 static NSString *const kTappingActivitySurveyIdentifier             = @"2-APHIntervalTapping-7259AC18-D711-47A6-ADBD-6CFCECDED1DF";
 static NSString *const kMemoryActivitySurveyIdentifier              = @"7-APHSpatialSpanMemory-4A04F3D0-AC05-11E4-AB27-0800200C9A66";
-static NSString *const kMyThoughtsSurveyIdentifier                  = @"8-MyThoughts-12ffde40-1551-4b48-aae2-8fef38d61b61";
+static NSString *const kMyThoughtsSurveyIdentifier                  = @"mythoughts";
+static NSString *const kPDRatingScaleSurveyIdentifier               = @"MDSUPDRS";
+static NSString *const kEnrollmentSurveyIdentifier                  = @"EnrollmentSurvey";
+static NSString *const kPDQuestionnaireSurveyIdentifier             = @"PDQ8";
+static NSString *const kStudyFeedbackSurveyIdentifier               = @"study_feedback";
+
+
 
 /*********************************************************************************/
 #pragma mark - Initializations Options
 /*********************************************************************************/
-static NSString *const kStudyIdentifier             = @"studyname";
-static NSString *const kAppPrefix                   = @"studyname";
+static NSString *const kStudyIdentifier             = @"Parkinson's";
+static NSString *const kAppPrefix                   = @"parkinson";
 static NSString *const kConsentPropertiesFileName   = @"APHConsentSection";
 
 static NSString *const kVideoShownKey = @"VideoShown";
@@ -170,16 +176,22 @@ static NSString *const kJsonSchedulesKey                = @"schedules";
     APCTaskReminder *voiceActivityReminder = [[APCTaskReminder alloc] initWithTaskID:kVoiceActivitySurveyIdentifier reminderBody:NSLocalizedString(@"Voice Activity", nil)];
     APCTaskReminder *tappingActivityReminder = [[APCTaskReminder alloc] initWithTaskID:kTappingActivitySurveyIdentifier reminderBody:NSLocalizedString(@"Tapping Activity", nil)];
     APCTaskReminder *memoryActivityReminder = [[APCTaskReminder alloc] initWithTaskID:kMemoryActivitySurveyIdentifier reminderBody:NSLocalizedString(@"Memory Activity", nil)];
-    APCTaskReminder *pdSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kStudyIdentifier reminderBody:NSLocalizedString(@"PD Survey", nil)];
     APCTaskReminder *myThoughtsSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kMyThoughtsSurveyIdentifier reminderBody:NSLocalizedString(@"My Thoughts", nil)];
+    APCTaskReminder *pdRatingSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kPDRatingScaleSurveyIdentifier reminderBody:NSLocalizedString(@"PD Rating Scale", nil)];
+    APCTaskReminder *enrollmentSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kEnrollmentSurveyIdentifier reminderBody:NSLocalizedString(@"Enrollment Survey", nil)];
+    APCTaskReminder *pdQuestionnaireSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kPDQuestionnaireSurveyIdentifier reminderBody:NSLocalizedString(@"PD Questionnaire", nil)];
+    APCTaskReminder *studyFeedbackSurveyReminder = [[APCTaskReminder alloc] initWithTaskID:kStudyFeedbackSurveyIdentifier reminderBody:NSLocalizedString(@"Study Feedback", nil)];
 
     [self.tasksReminder.reminders removeAllObjects];
     [self.tasksReminder manageTaskReminder:walkingActivityReminder];
     [self.tasksReminder manageTaskReminder:voiceActivityReminder];
     [self.tasksReminder manageTaskReminder:tappingActivityReminder];
     [self.tasksReminder manageTaskReminder:memoryActivityReminder];
-    [self.tasksReminder manageTaskReminder:pdSurveyReminder];
     [self.tasksReminder manageTaskReminder:myThoughtsSurveyReminder];
+    [self.tasksReminder manageTaskReminder:pdRatingSurveyReminder];
+    [self.tasksReminder manageTaskReminder:enrollmentSurveyReminder];
+    [self.tasksReminder manageTaskReminder:pdQuestionnaireSurveyReminder];
+    [self.tasksReminder manageTaskReminder:studyFeedbackSurveyReminder];
 
     if ([self doesPersisteStoreExist] == NO)
     {


### PR DESCRIPTION
Survey task ids didn't match what server was providing. In the future we'll want to make this dynamic and built off of server schedules rather than hardcoded, but this fixes the immediate issue for the time being.
