### PR TITLE
Bridge-846 CoreMotion permissions bug on pre-M7 iPhone

### DIFF
--- a/Parkinson/TasksAndSteps/WalkingControllers/APHWalkingTaskViewController.m
+++ b/Parkinson/TasksAndSteps/WalkingControllers/APHWalkingTaskViewController.m
@@ -238,8 +238,18 @@ static  NSString       *kScorePostureRecordsKey               = @"ScorePostureRe
 
 #pragma  mark  - Settings
 
+/*
+ On older iphones that do not have an M7 chip, the CMMotionActivity api is not available. However,
+ this activity will still work just using the accelerometer and gyroscope which do not require
+ special permissions. On iPhones with the M7, we should still be requesting access to CoreMotion.
+ */
 - (APCSignUpPermissionsType)requiredPermission {
-    return kAPCSignUpPermissionsTypeCoremotion;
+    if ([CMMotionActivityManager isActivityAvailable]) {
+        return kAPCSignUpPermissionsTypeCoremotion;
+    } else {
+        return kAPCSignUpPermissionsTypeNone;
+    }
+    
 }
 
 #pragma  mark  -  View Controller Methods


### PR DESCRIPTION
On pre-M7 iphones, the current permissions check tries to check an api that is not available which then fails. The app is treating this as a permission set to off that the user needs to go fix. Since the activity will still function with the accelerometer and gyroscope, the user should only be prompted to go turn on core motion if core motion it is available in their version of the iphone and it is turned off.
