### PR TITLE
BRIDGE-138 Change wording of question about meds

### DIFF
--- a/Parkinson/TasksAndSteps/APHParkinsonActivityViewController.h
+++ b/Parkinson/TasksAndSteps/APHParkinsonActivityViewController.h
@@ -52,14 +52,6 @@ extern  NSString  *const kMomentInDayStepIdentifier;
 
 extern  NSString  *const kMomentInDayFormat;
 
-extern  NSString  *kMomentInDayFormatTitle;
-
-extern  NSString  *kMomentInDayFormatItemText;
-extern  NSString  *kMomentInDayFormatChoiceJustWokeUp;
-extern  NSString  *kMomentInDayFormatChoiceTookMyMedicine;
-extern  NSString  *kMomentInDayFormatChoiceEvening;
-extern  NSString  *kMomentInDayFormatChoiceNone;
-
     //
     //    key for Parkinson Stashed Question Result
     //        from 'When Did You Take Your Medicine' Pre-Survey Question


### PR DESCRIPTION
Before an activity (if less than 20 minutes since last activity) there is a question about when was the last time the user took their Parkinson's Medication. Change the wording of the question and only ask once a month if the user is not taking medication.
